### PR TITLE
:bug: Fix #125

### DIFF
--- a/service/articlesrv.go
+++ b/service/articlesrv.go
@@ -436,7 +436,7 @@ func (srv *articleService) UpdateArticle(article *model.Article) (err error) {
 			tx.Rollback()
 		}
 	}()
-	if oldArticle.CreatedAt != article.CreatedAt {
+	if oldArticle.CreatedAt.Format("200601") != article.CreatedAt.Format("200601") {
 		// https://github.com/b3log/pipe/issues/106
 		if err = Archive.UnArchiveArticleWithoutTx(tx, oldArticle); nil != err {
 			return


### PR DESCRIPTION
原因：查询和更新在两个数据库事务中，应该是由于数据更新未提交导致了两边数据不一致，修改方法是让两边使用同一个事务，这样原函数名就不太合适了，所以去掉了后缀 `WithoutTx`。

另外：GORM 删除记录时使用了软删除，原实现方式可能会导致一个月份有多条 archive 记录，但只有一条可见，修改成不再删除 archive，但查询时过滤掉 article 数量为 0 的 archive。

还有一个小优化：如果更新 article 时，月份没有变化，则略过 archive 更新